### PR TITLE
Fix misleading if statement

### DIFF
--- a/ch6/board-reflux/public/js/app.js
+++ b/ch6/board-reflux/public/js/app.js
@@ -89,7 +89,7 @@ var NewMessage = React.createClass({displayName: "NewMessage",
 var MessageList = React.createClass({displayName: "MessageList",
   render: function(){
     var messages = this.props.messages
-    if (!messages.length > 0) return (
+    if (messages.length == 0) return (
       React.createElement("p", null, 
         "No messages yet"
       )


### PR DESCRIPTION
`!messages.length > 0` would actually translate to `(!messages.length) > 0`, which would be a `boolean` value compared to a number.

Although that would still work for the requirements of the project (since `false` would be translated to `0` and `true` to `1`), it was quite misleading to the reader, hence the change suggestion.